### PR TITLE
Change to INT signal

### DIFF
--- a/templates/default/sidekiq_monitrc.erb
+++ b/templates/default/sidekiq_monitrc.erb
@@ -8,6 +8,6 @@
 check process sidekiq_swarm
   matching "sidekiqswarm, managing"
   start program = "/bin/su - <%= @deploy[:user] %> -c 'cd <%= @deploy[:current_path] %> && RAILS_ENV=<%= @deploy[:rails_env] %> SIDEKIQ_PRELOAD= SIDEKIQ_MAXMEM_MB=<%= memory_limit_mb %> SIDEKIQ_COUNT=<%= sidekiq_process_count %> bundle exec sidekiqswarm -C <%= conf_file %> -t <%= sidekiq_timeout %> -r <%= @deploy[:current_path] %> <%= syslog %>'" with timeout 90 seconds
-  stop  program = "/bin/su - <%= @deploy[:user] %> -c 'kill -s TERM `pgrep -f "sidekiqswarm, managing <%= sidekiq_process_count %> processes"`'" with timeout 90 seconds
+  stop  program = "/bin/su - <%= @deploy[:user] %> -c 'kill -s INT `pgrep -f "sidekiqswarm, managing <%= sidekiq_process_count %> processes"`'" with timeout 90 seconds
 
 <% end %>


### PR DESCRIPTION
TERM doesn't seem to always restart the process. ctrl c uses SIGINT so I'm trying to see if that helps be more consistent.