### PR TITLE
Update opsworks_sidekiq::stop to stop the sidekiq_swarm process.

### DIFF
--- a/recipes/stop.rb
+++ b/recipes/stop.rb
@@ -5,7 +5,7 @@ include_recipe "opsworks_sidekiq::service"
 node[:deploy].each do |application, deploy|
 
   execute "stop Rails app #{application}" do
-    command "sudo monit stop -g sidekiq_#{application}_group"
+    command "sudo monit stop sidekiq_swarm"
   end
 
 end


### PR DESCRIPTION
We never updated the recipe to stop sidekiq swarm when migrating to use sidekiq swarm. This should properly stop all sidekiq processes via chef!